### PR TITLE
#49 Added new rules that drop all rows without weather data and did n…

### DIFF
--- a/notebooks/1.1-circles-to-many-noaa-stations-usa-weather-data.ipynb
+++ b/notebooks/1.1-circles-to-many-noaa-stations-usa-weather-data.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,16 +76,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<google.cloud.bigquery.client.Client at 0x104833be0>"
+       "<google.cloud.bigquery.client.Client at 0x11453dfd0>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {
     "scrolled": false
    },
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -347,7 +347,7 @@
        "[5 rows x 48 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -365,21 +365,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Set up Data name \n",
     "table_id = 'rec_initial_data_cleaning'\n",
     "\n",
-    "table_ref = dataset_ref.table(table_id)\n",
+    "table_ref = shared_dataset_ref.table(table_id)\n",
     "\n",
     "table_full = project + \".\"+ source_dataset_id + \".\" + \"rec_initial_data_cleaning\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,22 +478,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1047595, 66)"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df_circles_to_stations_weather_data.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Saving stations in csv COMPRESSED IN GZIP!!!\n",
-    "df_circles_to_stations_weather_data.to_csv(r'1.1-circles_to_many_stations_usa_weather_data_' + str(time_now) +  '.csv', compression = \"gzip\")\n",
-    "\n"
    ]
   },
   {
@@ -506,9 +506,216 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>int64_field_0</th>\n",
+       "      <th>circle_name</th>\n",
+       "      <th>country_state</th>\n",
+       "      <th>lat</th>\n",
+       "      <th>lon</th>\n",
+       "      <th>count_year</th>\n",
+       "      <th>count_date</th>\n",
+       "      <th>n_field_counters</th>\n",
+       "      <th>n_feeder_counters</th>\n",
+       "      <th>min_field_parties</th>\n",
+       "      <th>...</th>\n",
+       "      <th>gsn_flag</th>\n",
+       "      <th>hcn_crn_flag</th>\n",
+       "      <th>wmoid</th>\n",
+       "      <th>geohash_station</th>\n",
+       "      <th>temp_min_value</th>\n",
+       "      <th>temp_max_value</th>\n",
+       "      <th>precipitation_value</th>\n",
+       "      <th>temp_avg</th>\n",
+       "      <th>snow</th>\n",
+       "      <th>snwd</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>28806</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1977</td>\n",
+       "      <td>1977-01-01</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>28806</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1977</td>\n",
+       "      <td>1977-01-01</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>30036</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1978</td>\n",
+       "      <td>1977-12-29</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>30036</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1978</td>\n",
+       "      <td>1977-12-29</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>31321</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1979</td>\n",
+       "      <td>1978-12-30</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 66 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   int64_field_0      circle_name country_state        lat         lon  \\\n",
+       "0          28806  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "1          28806  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "2          30036  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "3          30036  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "4          31321  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "\n",
+       "   count_year  count_date  n_field_counters  n_feeder_counters  \\\n",
+       "0        1977  1977-01-01               4.0                NaN   \n",
+       "1        1977  1977-01-01               4.0                NaN   \n",
+       "2        1978  1977-12-29               5.0                NaN   \n",
+       "3        1978  1977-12-29               5.0                NaN   \n",
+       "4        1979  1978-12-30               2.0                NaN   \n",
+       "\n",
+       "   min_field_parties  ...  gsn_flag  hcn_crn_flag  wmoid  geohash_station  \\\n",
+       "0                NaN  ...                            NaN             zcpk   \n",
+       "1                NaN  ...                            NaN             zcpk   \n",
+       "2                NaN  ...                            NaN             zcpk   \n",
+       "3                NaN  ...                            NaN             zcpk   \n",
+       "4                NaN  ...                            NaN             zcpk   \n",
+       "\n",
+       "   temp_min_value  temp_max_value precipitation_value  temp_avg  snow  snwd  \n",
+       "0             NaN             NaN                 NaN       NaN   NaN   NaN  \n",
+       "1             NaN             NaN                 NaN       NaN   NaN   NaN  \n",
+       "2             NaN             NaN                 NaN       NaN   NaN   NaN  \n",
+       "3             NaN             NaN                 NaN       NaN   NaN   NaN  \n",
+       "4             NaN             NaN                 NaN       NaN   NaN   NaN  \n",
+       "\n",
+       "[5 rows x 66 columns]"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df_circles_to_stations_weather_data.head()"
    ]
@@ -523,9 +730,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "How many rows in dataset with missing vals:  1047595\n",
+      "Missing min temperature: 981842\n",
+      "Missing max temperature: 981834\n",
+      "Missing avg temperature: 1039022\n",
+      "Missing snow temperature: 955619\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -549,28 +768,276 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Remove empty min/max temperature\n",
+    "## Remove rows with empty weather data\n",
     "Create new data frame"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1047595, 66)"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "ref=df_circles_to_stations_weather_data.temp_min_value\n",
-    "paired_data=df_circles_to_stations_weather_data[ref.notna()]\n",
-    "paired_data.head()"
+    "#Inspect Shape before dropping data\n",
+    "df_circles_to_stations_weather_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
-    "paired_data.shape"
+    "# Drop the rows where min temp value, max temp value, average temp value, and snow are all NULL\n",
+    "paired_data_cleaned = df_circles_to_stations_weather_data.dropna(subset=['temp_min_value', 'temp_max_value', 'temp_avg', 'snow'], how='all')\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(109624, 66)"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "paired_data_cleaned.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>int64_field_0</th>\n",
+       "      <th>circle_name</th>\n",
+       "      <th>country_state</th>\n",
+       "      <th>lat</th>\n",
+       "      <th>lon</th>\n",
+       "      <th>count_year</th>\n",
+       "      <th>count_date</th>\n",
+       "      <th>n_field_counters</th>\n",
+       "      <th>n_feeder_counters</th>\n",
+       "      <th>min_field_parties</th>\n",
+       "      <th>...</th>\n",
+       "      <th>gsn_flag</th>\n",
+       "      <th>hcn_crn_flag</th>\n",
+       "      <th>wmoid</th>\n",
+       "      <th>geohash_station</th>\n",
+       "      <th>temp_min_value</th>\n",
+       "      <th>temp_max_value</th>\n",
+       "      <th>precipitation_value</th>\n",
+       "      <th>temp_avg</th>\n",
+       "      <th>snow</th>\n",
+       "      <th>snwd</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>32617</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1980</td>\n",
+       "      <td>1979-12-18</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>-17.0</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>52625</td>\n",
+       "      <td>Amchitka Island</td>\n",
+       "      <td>US-AK</td>\n",
+       "      <td>51.409713</td>\n",
+       "      <td>179.284881</td>\n",
+       "      <td>1993</td>\n",
+       "      <td>1992-12-20</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>zcpk</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>90930</td>\n",
+       "      <td>Caribou</td>\n",
+       "      <td>US-ME</td>\n",
+       "      <td>46.912573</td>\n",
+       "      <td>-67.947428</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>2011-12-28</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>GSN</td>\n",
+       "      <td></td>\n",
+       "      <td>72712</td>\n",
+       "      <td>f2rd</td>\n",
+       "      <td>-83.0</td>\n",
+       "      <td>78.0</td>\n",
+       "      <td>71.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>25.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>93245</td>\n",
+       "      <td>Caribou</td>\n",
+       "      <td>US-ME</td>\n",
+       "      <td>46.912573</td>\n",
+       "      <td>-67.947428</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>2012-12-29</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>GSN</td>\n",
+       "      <td></td>\n",
+       "      <td>72712</td>\n",
+       "      <td>f2rd</td>\n",
+       "      <td>-139.0</td>\n",
+       "      <td>-61.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>229.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>95653</td>\n",
+       "      <td>Caribou</td>\n",
+       "      <td>US-ME</td>\n",
+       "      <td>46.912573</td>\n",
+       "      <td>-67.947428</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>2014-01-01</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>GSN</td>\n",
+       "      <td></td>\n",
+       "      <td>72712</td>\n",
+       "      <td>f2rd</td>\n",
+       "      <td>-282.0</td>\n",
+       "      <td>-155.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>460.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 66 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    int64_field_0      circle_name country_state        lat         lon  \\\n",
+       "7           32617  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "9           52625  Amchitka Island         US-AK  51.409713  179.284881   \n",
+       "28          90930          Caribou         US-ME  46.912573  -67.947428   \n",
+       "30          93245          Caribou         US-ME  46.912573  -67.947428   \n",
+       "31          95653          Caribou         US-ME  46.912573  -67.947428   \n",
+       "\n",
+       "    count_year  count_date  n_field_counters  n_feeder_counters  \\\n",
+       "7         1980  1979-12-18               4.0                NaN   \n",
+       "9         1993  1992-12-20               2.0                0.0   \n",
+       "28        2012  2011-12-28              10.0                3.0   \n",
+       "30        2013  2012-12-29              10.0                4.0   \n",
+       "31        2014  2014-01-01               7.0                5.0   \n",
+       "\n",
+       "    min_field_parties  ...  gsn_flag  hcn_crn_flag  wmoid  geohash_station  \\\n",
+       "7                 NaN  ...                            NaN             zcpk   \n",
+       "9                 1.0  ...                            NaN             zcpk   \n",
+       "28                1.0  ...       GSN                72712             f2rd   \n",
+       "30                2.0  ...       GSN                72712             f2rd   \n",
+       "31                1.0  ...       GSN                72712             f2rd   \n",
+       "\n",
+       "    temp_min_value  temp_max_value precipitation_value  temp_avg  snow   snwd  \n",
+       "7            -17.0            17.0                 5.0       NaN   3.0    0.0  \n",
+       "9              NaN             NaN                 NaN       NaN   0.0    0.0  \n",
+       "28           -83.0            78.0                71.0       NaN   8.0   25.0  \n",
+       "30          -139.0           -61.0                 0.0       NaN   0.0  229.0  \n",
+       "31          -282.0          -155.0                 0.0       NaN   3.0  460.0  \n",
+       "\n",
+       "[5 rows x 66 columns]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "paired_data_cleaned.head()"
    ]
   },
   {
@@ -582,39 +1049,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The total number of records in this data set is:  109624\n"
+     ]
+    }
+   ],
    "source": [
-    "print(\"The total number of records in this data set is: \", len(paired_data.circle_name))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Only Data in the USA\n",
-    "Create new data frame for stations only for stations located in the USA"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "paired_data_usa = paired_data[paired_data.id.str.slice(stop=2)==\"US\"]\n",
-    "print(\"The number of rows station usa weather data: \", len(paired_data_usa))"
+    "print(\"The total number of records in this data set is: \", len(paired_data_cleaned.circle_name))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Saving stations in csv COMPRESSED IN GZIP!!!\n",
-    "paired_data_usa.to_csv(r'1.1-circles_to_many_stations_usa_weather_data_' + str(time_now) +  '.csv', compression = \"gzip\")\n",
+    "paired_data__cleaned_usa.to_csv(r'1.1-circles_to_many_stations_usa_weather_data_' + str(time_now) +  '.csv', compression = \"gzip\")\n",
     "\n"
    ]
   },


### PR DESCRIPTION
---
name: Added new rules that drop all rows without weather data and did not drop noaa stations not in the US
---

# High Level Changes
1.1-circles-to-many-noaa-stations-usa-weather-data.ipynb was producing a file that drops rows based on if they are missing min temp, I have updated the file to drop rows only if they are missing ALL the weather elements.  It also no longer drops mated stations that are outside the US. 

# Necessary Details
The resulting file is 109, 624 rows down
