### PR TITLE
Feature/download raw

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -25,7 +25,8 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
 
 # Paths to project directories.
 PATHS = {
-    "raw": os.path.join(ROOT, "data", "Cloud_Data"),
+    "raw": os.path.join(ROOT, "data", "Cloud_Data",
+                        "cbc_effort_weather_1900-2018.txt"),
 }
 
 
@@ -42,7 +43,7 @@ def download_raw(url=None, path=None):
 
     # Use the standard path by default.
     if not path:
-        path = PATHS["raw"]
+        path = os.path.dirname(PATHS["raw"])
         
     cwd = os.getcwd()
     os.chdir(path)
@@ -52,11 +53,11 @@ def download_raw(url=None, path=None):
 
 if __name__ == "__main__":
     # Make the data/raw/ directory if it doesn't exist.
-    pathlib.Path(PATHS["raw"]).mkdir(parents=True, exist_ok=True)
+    datadir = pathlib.Path(os.path.dirname(PATHS["raw"]))
+    datadir.mkdir(parents=True, exist_ok=True)
 
     # Download the raw data if the file doesn't already exist.
-    filename = os.path.join(PATHS["raw"], "cbc_effort_weather_1900-2018.txt")
-    if os.path.isfile(filename):
-        print(filename, "already exists.")
+    if os.path.isfile(PATHS["raw"]):
+        print(PATHS["raw"], "already exists.")
     else:
         download_raw()

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -54,5 +54,9 @@ if __name__ == "__main__":
     # Make the data/raw/ directory if it doesn't exist.
     pathlib.Path(PATHS["raw"]).mkdir(parents=True, exist_ok=True)
 
-    # Download the raw data.
-    download_raw()
+    # Download the raw data if the file doesn't already exist.
+    filename = os.path.join(PATHS["raw"], "cbc_effort_weather_1900-2018.txt")
+    if os.path.isfile(filename):
+        print(filename, "already exists.")
+    else:
+        download_raw()

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -25,7 +25,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
 
 # Paths to project directories.
 PATHS = {
-    "raw": os.path.join(ROOT, "data", "raw"),
+    "raw": os.path.join(ROOT, "data", "Cloud_Data"),
 }
 
 

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -1,0 +1,58 @@
+"""Utilities for downloading project data.
+
+Top level function :func:`scripts.download.download_raw` downloads the raw
+Christmas Bird Count project data from Google Drive.
+
+Run this module as a script to automatically download the project data into
+``data/raw/`` under the project root. If the directory doesn't already exist,
+this script will create it.
+
+"""
+import gdown
+import os
+import pathlib
+
+
+# URLs for project data.
+URLS = {
+    "raw": "https://drive.google.com/uc?id=1vwC_m-wFaX-4brrHOrTVqVFDZDJ6y3gN",
+}
+
+
+# Project root directory.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
+
+
+# Paths to project directories.
+PATHS = {
+    "raw": os.path.join(ROOT, "data", "raw"),
+}
+
+
+def download_raw(url=None, path=None):
+    """Download the raw Christmas Bird Count data.
+
+    Args:
+        url (str): URL from which to fetch raw data.
+        path (str): Directory in which to store raw data.
+    """
+    # Use the standard URL by default.
+    if not url:
+        url = URLS["raw"]
+
+    # Use the standard path by default.
+    if not path:
+        path = PATHS["raw"]
+        
+    cwd = os.getcwd()
+    os.chdir(path)
+    gdown.download(url)
+    os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    # Make the data/raw/ directory if it doesn't exist.
+    pathlib.Path(PATHS["raw"]).mkdir(parents=True, exist_ok=True)
+
+    # Download the raw data.
+    download_raw()

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -62,7 +62,7 @@ def download(url, path):
 
 
 if __name__ == "__main__":
-    # Make the data/raw/ directory if it doesn't exist.
+    # Make the data/Cloud_Data/ directory if it doesn't exist.
     datadir = pathlib.Path(os.path.dirname(PATHS["raw"]))
     datadir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -16,6 +16,7 @@ import pathlib
 # URLs for project data.
 URLS = {
     "raw": "https://drive.google.com/uc?id=1vwC_m-wFaX-4brrHOrTVqVFDZDJ6y3gN",
+    "clean": "https://drive.google.com/uc?id=1f_qNLG_WwPAUqIeLlD4uxRK4T8oK8sx0",
 }
 
 
@@ -27,26 +28,35 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
 PATHS = {
     "raw": os.path.join(ROOT, "data", "Cloud_Data",
                         "cbc_effort_weather_1900-2018.txt"),
+    "clean": os.path.join(ROOT, "data", "Cloud_Data",
+                        "1.0-rec-initial-data-cleaning.txt"),
 }
 
 
-def download_raw(url=None, path=None):
-    """Download the raw Christmas Bird Count data.
+def download_raw():
+    """Download the raw Christmas Bird Count data."""
+    download(URLS["raw"], PATHS["raw"])
+
+
+def download_clean():
+    """Download the cleaned Christmas Bird Count data.
+
+    .. note::
+       For reproducibility, it might be better to clean the raw data locally
+       rather than downloading a cleaned version from the cloud.
+    """
+    download(URLS["clean"], PATHS["clean"])
+
+
+def download(url, path):
+    """Download project data from the cloud.
 
     Args:
-        url (str): URL from which to fetch raw data.
-        path (str): Directory in which to store raw data.
+        url (str): URL from which to fetch data.
+        path (str): Directory in which to store data.
     """
-    # Use the standard URL by default.
-    if not url:
-        url = URLS["raw"]
-
-    # Use the standard path by default.
-    if not path:
-        path = os.path.dirname(PATHS["raw"])
-        
     cwd = os.getcwd()
-    os.chdir(path)
+    os.chdir(os.path.dirname(path))
     gdown.download(url)
     os.chdir(cwd)
 
@@ -56,8 +66,9 @@ if __name__ == "__main__":
     datadir = pathlib.Path(os.path.dirname(PATHS["raw"]))
     datadir.mkdir(parents=True, exist_ok=True)
 
-    # Download the raw data if the file doesn't already exist.
-    if os.path.isfile(PATHS["raw"]):
-        print(PATHS["raw"], "already exists.")
-    else:
-        download_raw()
+    # Download the each file if it doesn't already exist.
+    for file in ["raw", "clean"]:
+        if os.path.isfile(PATHS[file]):
+            print(PATHS[file], "already exists.")
+        else:
+            download(URLS[file], PATHS[file])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+import setuptools
+
+setuptools.setup(
+    name="audobon-cbc",
+    version="0.1",
+    packages=setuptools.find_packages(),
+)

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,7 @@ setuptools.setup(
     name="audobon-cbc",
     version="0.1",
     packages=setuptools.find_packages(),
+    install_requires=[
+        "gdown>=3.11.1",
+    ]
 )


### PR DESCRIPTION
I added `scripts/download.py` to automatically download the raw Christmas Bird Count data to a local repository. The module depends on [gdown](https://github.com/wkentaro/gdown) to interface with Google Drive. To make it more user friendly, I converted the `scripts/` directory into a package. That way, if you are in an environment where the package is installed you can just type:

```
python -m scripts.download
```

to install download the data to the right directory.

We could easily extend the module to download the other interim datasets. Alternatively, we could convert some of the data processing notebooks into modules so that any user can regenerate those interim data from the raw data; I can see reproducibility benefits to that approach.

If it's useful to you, I'd be happy to (1) add a Makefile so that users can just call `make download` to get their data set up and (2) provide instructions in the docs.